### PR TITLE
Add Automatic Crafting Table Mk2 as an importable tile entity in crafting logistics pipes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,13 @@ repositories {
 			artifact()
 		}
 	}
+	flatDir {
+		dirs 'libs'
+
+		content {
+			includeGroup 'libs'
+		}
+	}
 }
 
 sourceSets {
@@ -45,6 +52,7 @@ dependencies {
 	modImplementation name: "buildcraft", version: "A-1.4.7-3.4.5", ext: "jar"
 	modImplementation name: "industrialcraft-2", version: "1.115.231-lf", ext: "jar"
 	modImplementation name: "immibis-core", version: "52.4.6a", ext: "jar"
+	modImplementation 'libs:LogisticsPipes'
 
 	modCompileOnly name: "CodeChickenCore", version: "0.8.1.6", ext: "jar"
 	modCompileOnly name: "NotEnoughItems", version: "1.4.7.4", ext: "jar"

--- a/build.gradle
+++ b/build.gradle
@@ -28,13 +28,6 @@ repositories {
 			artifact()
 		}
 	}
-	flatDir {
-		dirs 'libs'
-
-		content {
-			includeGroup 'libs'
-		}
-	}
 }
 
 sourceSets {
@@ -52,7 +45,7 @@ dependencies {
 	modImplementation name: "buildcraft", version: "A-1.4.7-3.4.5", ext: "jar"
 	modImplementation name: "industrialcraft-2", version: "1.115.231-lf", ext: "jar"
 	modImplementation name: "immibis-core", version: "52.4.6a", ext: "jar"
-	modImplementation 'libs:LogisticsPipes'
+	modImplementation name: "LogisticsPipes", version: "MC1.4.7-0.7.0.98a", ext: "jar"
 
 	modCompileOnly name: "CodeChickenCore", version: "0.8.1.6", ext: "jar"
 	modCompileOnly name: "NotEnoughItems", version: "1.4.7.4", ext: "jar"

--- a/src/main/java/immibis/tubestuff/AutoCraftingMk2CraftingRecipeProvider.java
+++ b/src/main/java/immibis/tubestuff/AutoCraftingMk2CraftingRecipeProvider.java
@@ -1,0 +1,77 @@
+package immibis.tubestuff;
+
+import logisticspipes.proxy.interfaces.ICraftingRecipeProvider;
+import logisticspipes.utils.ItemIdentifier;
+import logisticspipes.utils.SimpleInventory;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.tileentity.TileEntity;
+
+public class AutoCraftingMk2CraftingRecipeProvider implements ICraftingRecipeProvider {
+    @Override
+    public boolean canOpenGui(TileEntity tileEntity) {
+        return tileEntity instanceof TileAutoCraftingMk2;
+    }
+
+    @Override
+    public boolean importRecipe(TileEntity tileEntity, SimpleInventory inventory) {
+        if (!(tileEntity instanceof TileAutoCraftingMk2))
+            return false;
+
+        TileAutoCraftingMk2 crafterMk2 = (TileAutoCraftingMk2) tileEntity;
+        ItemStack[][] inputMatrix = crafterMk2.recipeInputs;
+        IRecipe recipe = crafterMk2.cachedRecipe;
+        if (inputMatrix == null || recipe == null)
+            return false;
+        ItemStack result = crafterMk2.cachedRecipe.getRecipeOutput();
+        if (result == null)
+            return false;
+
+        inventory.setInventorySlotContents(9, result.copy());
+
+        for (int i=0; i < inputMatrix.length; i++) {
+            ItemStack stackInSlot = null;
+            // Table can have multiple ItemStacks for the same slot if oredictionary mode is enabled
+            ItemStack[] possibleInputs = inputMatrix[i];
+            if (possibleInputs.length > 0) {
+                stackInSlot = possibleInputs[0].copy();
+                stackInSlot.stackSize = 1;
+            }
+            inventory.setInventorySlotContents(i, stackInSlot);
+        }
+
+        this.mergeStacks(inventory);
+
+        return true;
+    }
+
+    private void mergeStacks(IInventory inventory) {
+        for (int i = 0; i < inventory.getSizeInventory() - 1; ++i) {
+            ItemStack stackInSlot = inventory.getStackInSlot(i);
+            if (stackInSlot != null) {
+                ItemIdentifier itemInSlot = ItemIdentifier.get(stackInSlot);
+
+                for (int j = i + 1; j < inventory.getSizeInventory() - 1; ++j) {
+                    ItemStack stackInOtherSlot = inventory.getStackInSlot(j);
+                    if (stackInOtherSlot != null && itemInSlot == ItemIdentifier.get(stackInOtherSlot)) {
+                        stackInSlot.stackSize += stackInOtherSlot.stackSize;
+                        inventory.setInventorySlotContents(j, null);
+                    }
+                }
+            }
+        }
+
+        for (int i = 0; i < inventory.getSizeInventory() - 1; ++i) {
+            if (inventory.getStackInSlot(i) == null) {
+                for (int j = i + 1; j < inventory.getSizeInventory() - 1; ++j) {
+                    if (inventory.getStackInSlot(j) != null) {
+                        inventory.setInventorySlotContents(i, inventory.getStackInSlot(j));
+                        inventory.setInventorySlotContents(j, null);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/immibis/tubestuff/TileAutoCraftingMk2.java
+++ b/src/main/java/immibis/tubestuff/TileAutoCraftingMk2.java
@@ -45,7 +45,7 @@ public class TileAutoCraftingMk2 extends TileBasicInventory implements ISidedInv
 	
 	// recipeInputs[slotNumber] = array of possible stacks to fill that slot
 	public ItemStack[][] recipeInputs = new ItemStack[9][0];
-	private IRecipe cachedRecipe;
+	protected IRecipe cachedRecipe;
 	private boolean invChanged = true;
 	private boolean recipeChanged = true;
 	private boolean outputFull = false;

--- a/src/main/java/immibis/tubestuff/TubeStuff.java
+++ b/src/main/java/immibis/tubestuff/TubeStuff.java
@@ -1,5 +1,6 @@
 package immibis.tubestuff;
 
+import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.common.registry.LanguageRegistry;
 import ic2.api.Ic2Recipes;
@@ -16,6 +17,7 @@ import immibis.core.api.porting.SidedProxy;
 import java.util.ArrayList;
 import java.util.List;
 
+import logisticspipes.proxy.SimpleServiceLocator;
 import org.lwjgl.LWJGLException;
 import org.lwjgl.opengl.Display;
 import org.lwjgl.opengl.PixelFormat;
@@ -204,6 +206,11 @@ public class TubeStuff extends PortableBaseMod implements IPacketMap, IGuiHandle
 		}
 
 		APILocator.getNetManager().listen(this);
+	}
+
+	@Mod.PostInit
+	public void postInit(FMLPostInitializationEvent evt) {
+		SimpleServiceLocator.addCraftingRecipeProvider(new AutoCraftingMk2CraftingRecipeProvider());
 	}
 
 	public static final boolean areItemsEqual(ItemStack recipe, ItemStack input)


### PR DESCRIPTION
Copied from [UpsilonFixes](https://git.sleeping.town/Rewind/UpsilonFixes/pulls/5).

Currently this requires manually putting LP under `libs/LogisticsPipes.jar`, because I didn't set up a repository. Would probably be good to add it to your webserver.